### PR TITLE
Fix mixed object and native types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 8.1, 8.2]
+                php: [8.0, 8.1, 8.2, 8.3, 8.4]
 
         steps:
             -

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE)
 [![Build Status][ico-github-actions]][link-github-actions]
-[![Quality Score][ico-code-quality]][link-code-quality]
 
 ## PHP8 class generator
 
@@ -98,8 +97,6 @@ $dummyPhpGenerator->generate();
 [ico-version]: https://img.shields.io/packagist/v/Prometee/php-class-generator.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
 [ico-github-actions]: https://github.com/Prometee/PhpClassGenerator/workflows/Build/badge.svg
-[ico-code-quality]: https://img.shields.io/scrutinizer/g/Prometee/PhpClassGenerator.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/prometee/php-class-generator
 [link-github-actions]: https://github.com/Prometee/PhpClassGenerator/actions?query=workflow%3A"Build"
-[link-code-quality]: https://scrutinizer-ci.com/g/Prometee/PhpClassGenerator

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "ext-iconv": "*",
-        "symfony/string": "^5.4|^6.4|^7.1"
+        "symfony/string": "^5.4|^6.4|^7.4|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,10 +10,6 @@ parameters:
     ignoreErrors:
         - identifier: missingType.iterableValue
         -
-            message: '/Variable \$body in empty\(\) always exists and is not falsy\./'
-            count: 1
-            path: src/View/Class_/ClassView.php
-        -
             message: '/Property Tests\\Prometee\\PhpClassGenerator\\Resources\\MixedTest::\$anOtherMixedFieldWithArray \(array<Tests\\Prometee\\PhpClassGenerator\\Resources\\MixedTest>\) does not accept array\./'
             count: 1
             path: tests/Resources/MixedTest.php

--- a/src/Model/Method/IsserSetter.php
+++ b/src/Model/Method/IsserSetter.php
@@ -23,7 +23,7 @@ class IsserSetter extends GetterSetter implements IsserSetterInterface
         return false;
     }
 
-    public function configureGetter(string $indent = null): void
+    public function configureGetter(?string $indent = null): void
     {
         if (null === $this->property) {
             return;

--- a/src/Model/Method/MethodParameter.php
+++ b/src/Model/Method/MethodParameter.php
@@ -98,9 +98,12 @@ class MethodParameter extends AbstractModel implements MethodParameterInterface
 
     public function getPhpTypeFromTypes(): string
     {
-        $type = self::getPhpType($this->types);
+        $types = [];
+        foreach ($this->types as $type) {
+            $types[] = $this->uses->addRawUseOrReturnType($type);
+        }
 
-        return $this->uses->addRawUseOrReturnType($type);
+        return self::getPhpType($types);
     }
 
     public function getPhpDocType(): string

--- a/src/Model/Other/Uses.php
+++ b/src/Model/Other/Uses.php
@@ -30,6 +30,11 @@ class Uses extends AbstractModel implements UsesInterface
 
     public function isUsable(string $str): bool
     {
+        // Union types (e.g., "stdClass|false") are not usable as a single import
+        if (str_contains($str, '|')) {
+            return false;
+        }
+
         if (1 === preg_match('#\\\\#', $str)) {
             return true;
         }

--- a/src/View/AbstractView.php
+++ b/src/View/AbstractView.php
@@ -11,7 +11,7 @@ abstract class AbstractView implements ViewInterface
     /** @var non-empty-string */
     protected string $eol = PHP_EOL;
 
-    public function render(string $indent = null, string $eol = null): ?string
+    public function render(?string $indent = null, ?string $eol = null): ?string
     {
         $this->indent = $indent ?? $this->indent;
         $this->eol = $eol ?? $this->eol;

--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -12,7 +12,7 @@ interface ViewInterface
      *
      * @return string|null
      */
-    public function render(string $indent = null, string $eol = null): ?string;
+    public function render(?string $indent = null, ?string $eol = null): ?string;
 
     /** @param non-empty-string $eol */
     public function setEol(string $eol): void;

--- a/tests/PhpGeneratorTest.php
+++ b/tests/PhpGeneratorTest.php
@@ -655,4 +655,28 @@ class PhpGeneratorTest extends TestCase
         $this->assertTrue($this->dummyPhpGenerator->generate());
         $this->assertFileEquals(__DIR__ . '/Resources/AttributeTest.php', $this->path . '/AttributeTest.php');
     }
+
+    public function testGenerateMixedObjectAndNativeTypes(): void
+    {
+        $classesConfig = [
+            [
+                'class' => 'MixedObjectAndNativeTypesTest',
+                'type' => 'final',
+                'properties' => [
+                    0 => [
+                        'name' => 'aMixedObjectAndNativeTypesField',
+                        'types' => [
+                            0 => '\\stdClass',
+                            1 => 'false',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->dummyPhpGenerator->setClassesConfig($classesConfig);
+
+        $this->assertTrue($this->dummyPhpGenerator->generate());
+        $this->assertFileEquals(__DIR__ . '/Resources/MixedObjectAndNativeTypesTest.php', $this->path . '/MixedObjectAndNativeTypesTest.php');
+    }
 }

--- a/tests/Resources/MixedObjectAndNativeTypesTest.php
+++ b/tests/Resources/MixedObjectAndNativeTypesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Prometee\PhpClassGenerator\Resources;
+
+use stdClass;
+
+final class MixedObjectAndNativeTypesTest
+{
+    public function __construct(private stdClass|false $aMixedObjectAndNativeTypesField)
+    {
+    }
+
+    public function getAMixedObjectAndNativeTypesField(): stdClass|false
+    {
+        return $this->aMixedObjectAndNativeTypesField;
+    }
+
+    public function setAMixedObjectAndNativeTypesField(
+        stdClass|false $aMixedObjectAndNativeTypesField
+    ): void {
+        $this->aMixedObjectAndNativeTypesField = $aMixedObjectAndNativeTypesField;
+    }
+}


### PR DESCRIPTION
This pull request updates dependencies, improves support for union types in generated PHP classes, and adds new tests to validate this functionality. The most important changes include expanding the supported versions of `symfony/string`, refining how union types are handled during code generation, and introducing a new test for mixed object and native types.

**Dependency updates:**

* Expanded the supported versions of `symfony/string` in `composer.json` to include `^7.4` and `^8.0`, ensuring compatibility with newer Symfony releases.

**Union type handling improvements:**

* Updated `MethodParameter.php` so that all types in a union are processed correctly when generating PHP type hints, improving handling of mixed object and native types.
* Modified `Uses.php` to prevent attempts to import union types as a single use statement, which is invalid in PHP.

**Testing enhancements:**

* Added a new test case in `PhpGeneratorTest.php` to verify generation of classes with properties that use both object and native types in a union.
* Introduced a corresponding test resource file, `MixedObjectAndNativeTypesTest.php`, to validate the output of the generator for these mixed types.

**Documentation update:**

* Removed the code quality badge from `README.md` to reflect changes in project status or tooling. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-L105)